### PR TITLE
Support for 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Image](/others/light_api_logo_version_3.png)
 # LightAPI (Fork)
 Library for creating invisible light source.  
-Bukkit plugin for Minecraft server 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16.
+Bukkit plugin for Minecraft server 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17.
 
 - [ SPIGOT RESOURCE ](https://www.spigotmc.org/resources/lightapi-temporary-fork.48247/) ([ original ](https://www.spigotmc.org/resources/lightapi.4510/))
 - [ CONTRIBUTORS ](https://github.com/Qveshn/LightAPI/graphs/contributors) ([ original ](https://github.com/BeYkeRYkt/LightAPI/graphs/contributors))

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/common/src/main/java/ru/beykerykt/lightapi/server/nms/INMSHandler.java
+++ b/common/src/main/java/ru/beykerykt/lightapi/server/nms/INMSHandler.java
@@ -24,6 +24,7 @@
  */
 package ru.beykerykt.lightapi.server.nms;
 
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 
@@ -78,6 +79,7 @@ public interface INMSHandler {
 	@Deprecated
 	void sendChunkUpdate(World world, int chunkX, int y, int chunkZ, Player player);
 
+	@Deprecated
 	void sendChunkSectionsUpdate(
 			World world,
 			int chunkX,
@@ -87,6 +89,7 @@ public interface INMSHandler {
 			Collection<? extends Player> players
 	);
 
+	@Deprecated
 	void sendChunkSectionsUpdate(
 			World world,
 			int chunkX,
@@ -95,11 +98,35 @@ public interface INMSHandler {
 			int sectionsMaskBlock,
 			Player player
 	);
+	
+	void sendChunkSectionsUpdate(
+			World world,
+			int chunkX,
+			int chunkZ,
+			BitSet sectionsMaskSky,
+			BitSet sectionsMaskBlock,
+			Collection<? extends Player> players
+	);
+
+	void sendChunkSectionsUpdate(
+			World world,
+			int chunkX,
+			int chunkZ,
+			BitSet sectionsMaskSky,
+			BitSet sectionsMaskBlock,
+			Player player
+	);
 
 	// Utils...
+	@Deprecated
 	boolean isValidSectionY(int sectionY);
+	
+	boolean isValidSectionY(World world, int sectionY);
 
+	@Deprecated
 	int asSectionMask(int sectionY);
+	
+	BitSet asSectionMask(World world, int sectionY);
 
 	Collection<? extends Player> filterVisiblePlayers(
 			World world, int chunkX, int chunkZ, Collection<? extends Player> players

--- a/nms/v1_10_R1/pom.xml
+++ b/nms/v1_10_R1/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_11_R1/pom.xml
+++ b/nms/v1_11_R1/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_12_R1/pom.xml
+++ b/nms/v1_12_R1/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_13_R1/pom.xml
+++ b/nms/v1_13_R1/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_13_R2/pom.xml
+++ b/nms/v1_13_R2/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_14_R1/pom.xml
+++ b/nms/v1_14_R1/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_15_R1/pom.xml
+++ b/nms/v1_15_R1/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_16_R2/pom.xml
+++ b/nms/v1_16_R2/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_16_R3/pom.xml
+++ b/nms/v1_16_R3/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_17_R1/pom.xml
+++ b/nms/v1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>ru.beykerykt.lightapi.nms</groupId>
-    <artifactId>v1_16_R1</artifactId>
+    <artifactId>v1_17_R1</artifactId>
     <version>3.3.0</version>
 
     <properties>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.17-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ru.beykerykt.lightapi</groupId>

--- a/nms/v1_17_R1/src/main/java/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_17_R1.java
+++ b/nms/v1_17_R1/src/main/java/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_17_R1.java
@@ -1,0 +1,356 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2017 The ImplexDevOne Project
+ * Copyright (c) 2019 Vladimir Mikhailov <beykerykt@gmail.com>
+ * Copyright (c) 2020 Qveshn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.beykerykt.lightapi.server.nms.craftbukkit;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import net.minecraft.core.BlockPosition;
+import net.minecraft.core.SectionPosition;
+import net.minecraft.network.protocol.game.PacketPlayOutLightUpdate;
+import net.minecraft.server.level.LightEngineThreaded;
+import net.minecraft.server.level.WorldServer;
+import net.minecraft.util.thread.ThreadedMailbox;
+import net.minecraft.world.level.EnumSkyBlock;
+import net.minecraft.world.level.chunk.Chunk;
+import net.minecraft.world.level.lighting.LightEngineBlock;
+import net.minecraft.world.level.lighting.LightEngineGraph;
+import net.minecraft.world.level.lighting.LightEngineLayer;
+import net.minecraft.world.level.lighting.LightEngineLayerEventListener;
+import net.minecraft.world.level.lighting.LightEngineSky;
+import net.minecraft.world.level.lighting.LightEngineStorage;
+import ru.beykerykt.lightapi.LightType;
+import ru.beykerykt.lightapi.chunks.ChunkInfo;
+import ru.beykerykt.lightapi.server.nms.NmsHandlerBase;
+import ru.beykerykt.lightapi.utils.Debug;
+
+public class CraftBukkit_v1_17_R1 extends NmsHandlerBase {
+
+	private Field lightEngine_ThreadedMailbox;
+	private Field threadedMailbox_State;
+	private Method threadedMailbox_DoLoopStep;
+	private Field lightEngineLayer_d;
+	private Method lightEngineStorage_d;
+	private Method lightEngineGraph_a;
+
+	public CraftBukkit_v1_17_R1() {
+		try {
+			threadedMailbox_DoLoopStep = ThreadedMailbox.class.getDeclaredMethod("f");
+			threadedMailbox_DoLoopStep.setAccessible(true);
+			threadedMailbox_State = ThreadedMailbox.class.getDeclaredField("d");
+			threadedMailbox_State.setAccessible(true);
+			lightEngine_ThreadedMailbox = LightEngineThreaded.class.getDeclaredField("e");
+			lightEngine_ThreadedMailbox.setAccessible(true);
+
+			lightEngineLayer_d = LightEngineLayer.class.getDeclaredField("d");
+			lightEngineLayer_d.setAccessible(true);
+			lightEngineStorage_d = LightEngineStorage.class.getDeclaredMethod("d");
+			lightEngineStorage_d.setAccessible(true);
+			lightEngineGraph_a = LightEngineGraph.class.getDeclaredMethod(
+					"a", long.class, long.class, int.class, boolean.class);
+			lightEngineGraph_a.setAccessible(true);
+		} catch (Exception e) {
+			throw toRuntimeException(e);
+		}
+	}
+
+	@Override
+	public void createLight(World world, int x, int y, int z, LightType lightType, int light) {
+		setRawLightLevel(world, lightType, x, y, z, light);
+		recalculateLighting(world, x, y, z, lightType);
+	}
+
+	@Override
+	public void deleteLight(World world, int x, int y, int z, LightType lightType) {
+		setRawLightLevel(world, lightType, x, y, z, 0);
+		recalculateLighting(world, x, y, z, lightType);
+	}
+
+	@SuppressWarnings("SameParameterValue")
+	private void setRawLightLevel(World world, final LightType type, int blockX, int blockY, int blockZ, int lightlevel) {
+		WorldServer worldServer = ((CraftWorld) world).getHandle();
+		final BlockPosition position = new BlockPosition(blockX, blockY, blockZ);
+		final LightEngineThreaded lightEngine = worldServer.getChunkProvider().getLightEngine();
+
+		final int finalLightLevel = lightlevel < 0 ? 0 : lightlevel > 15 ? 15 : lightlevel;
+		executeSync(lightEngine, new Runnable() {
+			@Override
+			public void run() {
+				if (type == LightType.SKY) {
+					LightEngineLayerEventListener layer = lightEngine.a(EnumSkyBlock.a);
+					if (!(layer instanceof LightEngineSky)) return;
+					LightEngineSky les = (LightEngineSky) layer;
+					if (finalLightLevel == 0) {
+						les.a(position);
+					} else if (les.a(SectionPosition.a(position)) != null) {
+						try {
+							lightEngineLayer_a(les, position, finalLightLevel);
+						} catch (NullPointerException ignore) {
+							// To prevent problems with the absence of the NibbleArray, even
+							// if les.a(SectionPosition.a(position)) returns non-null value (corrupted data)
+						}
+					}
+				} else {
+					LightEngineLayerEventListener layer = lightEngine.a(EnumSkyBlock.b);
+					if (!(layer instanceof LightEngineBlock)) return;
+					LightEngineBlock leb = (LightEngineBlock) layer;
+					if (finalLightLevel == 0) {
+						leb.a(position);
+					} else if (leb.a(SectionPosition.a(position)) != null) {
+						try {
+							leb.a(position, finalLightLevel);
+						} catch (NullPointerException ignore) {
+							// To prevent problems with the absence of the NibbleArray, even
+							// if leb.a(SectionPosition.a(position)) returns non-null value (corrupted data)
+						}
+					}
+				}
+			}
+		});
+	}
+
+	@Override
+	protected void recalculateLighting(World world, int blockX, int blockY, int blockZ, final LightType type) {
+		WorldServer worldServer = ((CraftWorld) world).getHandle();
+		final LightEngineThreaded lightEngine = worldServer.getChunkProvider().getLightEngine();
+
+		// Do not recalculate if no changes!
+		if (!lightEngine.z_()) {
+			return;
+		}
+
+		executeSync(lightEngine, new Runnable() {
+			@Override
+			public void run() {
+				if (type == LightType.SKY) {
+					LightEngineSky les = (LightEngineSky) lightEngine.a(EnumSkyBlock.a);
+					les.a(Integer.MAX_VALUE, true, true);
+				} else {
+					LightEngineBlock leb = (LightEngineBlock) lightEngine.a(EnumSkyBlock.b);
+					leb.a(Integer.MAX_VALUE, true, true);
+				}
+			}
+		});
+	}
+	
+	@Override
+	public void sendChunkSectionsUpdate(World world, int chunkX, int chunkZ, int sectionsMaskSky, int sectionsMaskBlock,
+			Player player) {
+		throw new UnsupportedOperationException("This version of Minecraft allows different world heights for different worlds.");
+	}
+
+	@Override
+	public void sendChunkSectionsUpdate(
+			World world, int chunkX, int chunkZ, BitSet sectionsMaskSky, BitSet sectionsMaskBlock, Player player
+	) {
+		Chunk chunk = ((CraftWorld) world).getHandle().getChunkAt(chunkX, chunkZ);
+		//As Minecraft 1.17 supports extended world heights, a BitSet instead of an int is required to represent the chunk section bitmask
+		PacketPlayOutLightUpdate packet = new PacketPlayOutLightUpdate(
+				chunk.getPos(), chunk.getWorld().k_(), sectionsMaskSky, sectionsMaskBlock, true);
+		((CraftPlayer) player).getHandle().b.sendPacket(packet);
+	}
+
+	@Override
+	public boolean isValidSectionY(int sectionY) {
+		throw new UnsupportedOperationException("This version of Minecraft allows different world heights for different worlds.");
+	}
+	
+	@Override
+	public boolean isValidSectionY(World world, int sectionY) {
+		return sectionY >= (world.getMinHeight() >> 4) && sectionY < (world.getMaxHeight() >> 4);
+	}
+
+	@Override
+	public int asSectionMask(int sectionY) {
+		throw new UnsupportedOperationException("This version of Minecraft allows different world heights for different worlds.");
+	}
+	
+	@Override
+	public BitSet asSectionMask(World world, int sectionY) {
+		BitSet bitset = new BitSet();
+		bitset.set((sectionY - (world.getMinHeight() >> 4)) + 1, true);
+		return bitset;
+	}
+
+	@Override
+	protected int getViewDistance(Player player) {
+		return player.getClientViewDistance();
+	}
+
+	@SuppressWarnings({"StatementWithEmptyBody", "unchecked"})
+	private void executeSync(LightEngineThreaded lightEngine, Runnable task) {
+		try {
+			// ##### STEP 1: Pause light engine mailbox to process its tasks. #####
+			ThreadedMailbox<Runnable> threadedMailbox = (ThreadedMailbox<Runnable>) lightEngine_ThreadedMailbox
+					.get(lightEngine);
+			// State flags bit mask:
+			// 0x0001 - Closing flag (ThreadedMailbox is closing if non zero).
+			// 0x0002 - Busy flag (ThreadedMailbox performs a task from queue if non zero).
+			AtomicInteger stateFlags = (AtomicInteger) threadedMailbox_State.get(threadedMailbox);
+			int flags; // to hold values from stateFlags
+			long timeToWait = -1;
+			// Trying to set bit 1 in state bit mask when it is not set yet.
+			// This will break the loop in other thread where light engine mailbox processes the taks.
+			while (!stateFlags.compareAndSet(flags = stateFlags.get() & ~2, flags | 2)) {
+				if ((flags & 1) != 0) {
+					// ThreadedMailbox is closing. The light engine mailbox may also stop processing tasks.
+					// The light engine mailbox can be close due to server shutdown or unloading (closing) the world.
+					// I am not sure is it unsafe to process our tasks while the world is closing is closing,
+					// but will try it (one can throw exception here if it crashes the server).
+					if (timeToWait == -1) {
+						// Try to wait 3 seconds until light engine mailbox is busy.
+						timeToWait = System.currentTimeMillis() + 3 * 1000;
+						Debug.print("ThreadedMailbox is closing. Will wait...");
+					} else if (System.currentTimeMillis() >= timeToWait) {
+						throw new RuntimeException("Failed to enter critical section while ThreadedMailbox is closing");
+					}
+					try {
+						Thread.sleep(50);
+					} catch (InterruptedException ignored) {
+					}
+				}
+			}
+			try {
+				// ##### STEP 2: Safely running the task while the mailbox process is stopped. #####
+				task.run();
+			} finally {
+				// STEP 3: ##### Continue light engine mailbox to process its tasks. #####
+				// Firstly: Clearing busy flag to allow ThreadedMailbox to use it for running light engine tasks.
+				while (!stateFlags.compareAndSet(flags = stateFlags.get(), flags & ~2)) ;
+				// Secondly: IMPORTANT! The main loop of ThreadedMailbox was broken. Not completed tasks may still be
+				// in the queue. Therefore, it is important to start the loop again to process tasks from the queue.
+				// Otherwise, the main server thread may be frozen due to tasks stuck in the queue.
+				threadedMailbox_DoLoopStep.invoke(threadedMailbox);
+			}
+		} catch (InvocationTargetException e) {
+			throw toRuntimeException(e.getCause());
+		} catch (IllegalAccessException e) {
+			throw toRuntimeException(e);
+		}
+	}
+
+	private void lightEngineLayer_a(LightEngineLayer les, BlockPosition var0, int var1) {
+		try {
+			LightEngineStorage ls = (LightEngineStorage) lightEngineLayer_d.get(les);
+			lightEngineStorage_d.invoke(ls);
+			lightEngineGraph_a.invoke(les, 9223372036854775807L, var0.asLong(), 15 - var1, true);
+		} catch (InvocationTargetException e) {
+			throw toRuntimeException(e.getCause());
+		} catch (IllegalAccessException e) {
+			throw toRuntimeException(e);
+		}
+	}
+
+	private static RuntimeException toRuntimeException(Throwable e) {
+		if (e instanceof RuntimeException) {
+			return (RuntimeException) e;
+		}
+		Class cls = e.getClass();
+		return new RuntimeException(
+				String.format("(%s) %s", RuntimeException.class.getPackage().equals(cls.getPackage())
+						? cls.getSimpleName() : cls.getName(), e.getMessage()),
+				e);
+	}
+
+	private int getDeltaLight(int x, int dx) {
+		return (((x ^ ((-dx >> 4) & 15)) + 1) & (-(dx & 1)));
+	}
+
+	@Override
+	public List<ChunkInfo> collectChunks(
+			World world, int blockX, int blockY, int blockZ, LightType lightType, int lightLevel
+	) {
+		if (lightType != LightType.SKY || lightLevel < 15) {
+			return super.collectChunks(world, blockX, blockY, blockZ, lightType, lightLevel);
+		}
+		List<ChunkInfo> list = new ArrayList<ChunkInfo>();
+		Collection<Player> players = null;
+		for (int dx = -1; dx <= 1; dx++) {
+			int lightLevelX = lightLevel - getDeltaLight(blockX & 15, dx);
+			if (lightLevelX > 0) {
+				for (int dz = -1; dz <= 1; dz++) {
+					int lightLevelZ = lightLevelX - getDeltaLight(blockZ & 15, dz);
+					if (lightLevelZ > 0) {
+						if (lightLevelZ > getDeltaLight(blockY & 15, 1)) {
+							int sectionY = (blockY >> 4) + 1;
+							if (isValidSectionY(world, sectionY)) {
+								int chunkX = blockX >> 4;
+								int chunkZ = blockZ >> 4;
+								ChunkInfo cCoord = new ChunkInfo(
+										world,
+										chunkX + dx,
+										sectionY << 4,
+										chunkZ + dz,
+										players != null ? players : (players = world.getPlayers()));
+								list.add(cCoord);
+							}
+						}
+						for (int sectionY = blockY >> 4; sectionY >= -1; sectionY--) {
+							if (isValidSectionY(world, sectionY)) {
+								int chunkX = blockX >> 4;
+								int chunkZ = blockZ >> 4;
+								ChunkInfo cCoord = new ChunkInfo(
+										world,
+										chunkX + dx,
+										sectionY << 4,
+										chunkZ + dz,
+										players != null ? players : (players = world.getPlayers()));
+								list.add(cCoord);
+							}
+						}
+					}
+				}
+			}
+		}
+		return list;
+	}
+
+	@Override
+	public boolean isSupported(World world, LightType lightType) {
+		if (!(world instanceof CraftWorld)) {
+			return false;
+		}
+		WorldServer worldServer = ((CraftWorld) world).getHandle();
+		LightEngineThreaded lightEngine = worldServer.getChunkProvider().getLightEngine();
+		if (lightType == LightType.SKY) {
+			return lightEngine.a(EnumSkyBlock.a) instanceof LightEngineSky;
+		} else {
+			return lightEngine.a(EnumSkyBlock.b) instanceof LightEngineBlock;
+		}
+	}
+	
+}

--- a/nms/v1_8_R3/pom.xml
+++ b/nms/v1_8_R3/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_9_R1/pom.xml
+++ b/nms/v1_9_R1/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/nms/v1_9_R2/pom.xml
+++ b/nms/v1_9_R2/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -9,8 +9,8 @@
     <version>3.4.6</version>
 
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -18,6 +18,11 @@
         <dependency>
             <groupId>ru.beykerykt.lightapi</groupId>
             <artifactId>common</artifactId>
+            <version>3.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>ru.beykerykt.lightapi.nms</groupId>
+            <artifactId>v1_17_R1</artifactId>
             <version>3.3.0</version>
         </dependency>
         <dependency>

--- a/plugin/src/main/java/ru/beykerykt/lightapi/LightAPI.java
+++ b/plugin/src/main/java/ru/beykerykt/lightapi/LightAPI.java
@@ -108,6 +108,7 @@ public class LightAPI extends JavaPlugin implements Listener {
 		craftbukkit.getVersions().put("v1_16_R1", CraftBukkit_v1_16_R1.class);
 		craftbukkit.getVersions().put("v1_16_R2", CraftBukkit_v1_16_R2.class);
 		craftbukkit.getVersions().put("v1_16_R3", CraftBukkit_v1_16_R3.class);
+		craftbukkit.getVersions().put("v1_17_R1", CraftBukkit_v1_17_R1.class);
 		ServerModManager.registerServerMod(craftbukkit);
 
 		ServerModInfo spigot = new ServerModInfo("Spigot");
@@ -124,6 +125,7 @@ public class LightAPI extends JavaPlugin implements Listener {
 		spigot.getVersions().put("v1_16_R1", CraftBukkit_v1_16_R1.class);
 		spigot.getVersions().put("v1_16_R2", CraftBukkit_v1_16_R2.class);
 		spigot.getVersions().put("v1_16_R3", CraftBukkit_v1_16_R3.class);
+		spigot.getVersions().put("v1_17_R1", CraftBukkit_v1_17_R1.class);
 		ServerModManager.registerServerMod(spigot);
 
 		ServerModInfo paperspigot = new ServerModInfo("PaperSpigot");

--- a/plugin/src/main/java/ru/beykerykt/lightapi/chunks/ChunkUpdateInfo.java
+++ b/plugin/src/main/java/ru/beykerykt/lightapi/chunks/ChunkUpdateInfo.java
@@ -26,20 +26,21 @@ package ru.beykerykt.lightapi.chunks;
 import org.bukkit.entity.Player;
 import ru.beykerykt.lightapi.LightType;
 
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.HashSet;
 
 public class ChunkUpdateInfo {
 
-	private int sectionMaskSky = 0;
-	private int sectionMaskBlock = 0;
+	private BitSet sectionMaskSky = new BitSet();
+	private BitSet sectionMaskBlock = new BitSet();
 	private Collection<Player> players = new HashSet<Player>();
 
-	public void add(LightType lightType, int sectionMask, Collection<? extends Player> players) {
+	public void add(LightType lightType, BitSet sectionMask, Collection<? extends Player> players) {
 		if (lightType == LightType.SKY) {
-			this.sectionMaskSky |= sectionMask;
+			this.sectionMaskSky.or(sectionMask);
 		} else {
-			this.sectionMaskBlock |= sectionMask;
+			this.sectionMaskBlock.or(sectionMask);
 		}
 		add(players);
 	}
@@ -52,11 +53,11 @@ public class ChunkUpdateInfo {
 		return players;
 	}
 
-	public int getSectionMaskSky() {
+	public BitSet getSectionMaskSky() {
 		return sectionMaskSky;
 	}
 
-	public int getSectionMaskBlock() {
+	public BitSet getSectionMaskBlock() {
 		return sectionMaskBlock;
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,5 +29,6 @@
         <module>nms/v1_16_R1</module>
         <module>nms/v1_16_R2</module>
         <module>nms/v1_16_R3</module>
+        <module>nms/v1_17_R1</module>
     </modules>
 </project>


### PR DESCRIPTION
This PR adds support for 1.17.

Here are the changes:
- As 1.17 requires Java 16, it doesn't support compiling with Java version 1.6, so I've bumped them to Java 8 (1.8). The oldest version Minecraft 1.8 works with Java 8 already so it should be fine.
- Minecraft 1.17 supports extended world height and so different world might have different heights. I've added new methods that take in a world as an extra argument, for example, the calculation of Y section validity and bitmasks
- As there is extended world heights, a BitSet is now required by the Light Update Packet instead of an int for chunk section bitmask, therefore I've added new methods and changed ChunkUpdateInfo to use BitSet instead, then the different version implementations will use it directly or convert it to an int depending on the type they accept.
- NMS in 1.17 has been repackaged and field names have changed as well, those are also updated accordingly.

As those are some rather large changes, the way I did it might not be the way maintainers wanted, so changes are welcome and this can just be used as a reference.