### PR TITLE
Fixed issue with LightAPI for 1_16_R3

### DIFF
--- a/nms/v1_16_R3/src/main/java/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_16_R3.java
+++ b/nms/v1_16_R3/src/main/java/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_16_R3.java
@@ -323,7 +323,7 @@ public class CraftBukkit_v1_16_R3 extends NmsHandlerBase {
 
 	@Override
 	public int getMinLightHeight(World world) {
-		return world.getMinHeight() - 16;
+		return -16;
 	}
 
 	@Override


### PR DESCRIPTION
World.getMinHeight() does not exist for 1_16_R3. Fixed by reverting this change.